### PR TITLE
Fix Swift 6.1 build failure

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -35,9 +35,7 @@ jobs:
       - name: Run benchmarks on base and save baseline
         working-directory: base
         run: |
-          # Runs every benchmark suite and persists results to
-          # Benchmarks/.benchmarkBaselines/ci-base/
-          swift package --package-path Benchmarks benchmark baseline update ci-base \
+          swift package --package-path Benchmarks --allow-writing-to-package-directory benchmark baseline update base \
             --no-progress
 
       # ── PR head ──────────────────────────────────────────────────────────────
@@ -46,19 +44,27 @@ jobs:
         with:
           path: pr
 
-      - name: Copy baseline into PR workspace
+      - name: Copy base baseline into PR workspace
         run: |
           mkdir -p pr/Benchmarks/.benchmarkBaselines
           cp -r base/Benchmarks/.benchmarkBaselines/. pr/Benchmarks/.benchmarkBaselines/
 
+      - name: Run benchmarks on PR head and save baseline
+        working-directory: pr
+        run: |
+          swift package --package-path Benchmarks --allow-writing-to-package-directory benchmark baseline update head \
+            --no-progress
+
       - name: Compare PR head against base baseline
         working-directory: pr
-        # Runs the full suite, compares against the saved baseline, writes
-        # a human-readable delta table to stdout.  The exit code is non-zero
-        # when regressions exceed the threshold — we capture it but don't fail CI.
+        # Compares two saved baselines — no re-run needed.  The exit code is
+        # non-zero when regressions exceed the threshold; captured but not fatal.
+        # --format markdown folds passing benchmarks into <details> to keep the
+        # PR comment small and shows regressions prominently.
         run: |
-          swift package --package-path Benchmarks benchmark baseline compare ci-base \
+          swift package --package-path Benchmarks --allow-writing-to-package-directory benchmark baseline compare base head \
             --no-progress \
+            --format markdown \
             2>&1 | tee ../benchmark-delta.txt || true
 
       # ── Comment ──────────────────────────────────────────────────────────────
@@ -74,19 +80,17 @@ jobs:
               delta = 'Benchmark comparison unavailable (build error or no matching benchmarks).';
             }
 
+            const MAX_BODY = 60000;
+            if (delta.length > MAX_BODY) {
+              delta = delta.slice(0, MAX_BODY) + '\n\n…(truncated — see full log in Actions)';
+            }
+
             const MARKER = '<!-- swift-graphs-benchmarks -->';
             const body = [
               MARKER,
               '## ⚡ Benchmark comparison',
               '',
-              '<details>',
-              '<summary>Show results — release build, macOS 15, p90</summary>',
-              '',
-              '```',
-              delta || 'No differences found.',
-              '```',
-              '',
-              '</details>',
+              delta || '_No differences found._',
               '',
               '> ℹ️ Results may vary due to runner noise. Regressions are **advisory** — they do not block merge.',
             ].join('\n');

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,10 @@ jobs:
           - os: macos-15
             swift: "6.0"
             extra: ""
+          # Swift 6.1 — validates Package@swift-6.0.swift on 6.1 toolchain (catches compiler(>=6.x) guard regressions)
+          - os: macos-15
+            swift: "6.1"
+            extra: ""
           # Swift 6.2 default traits — validates Package@swift-6.2.swift (Pathfinding + Connectivity)
           - os: macos-15
             swift: "6.2"
@@ -64,6 +68,9 @@ jobs:
             build_only: true
           # Swift 6.0 — validates Package@swift-6.0.swift on Linux
           - swift: "6.0"
+            extra: ""
+          # Swift 6.1 — validates Package@swift-6.0.swift on Linux 6.1 toolchain
+          - swift: "6.1"
             extra: ""
           # Swift 6.2 all traits — full coverage on Linux
           - swift: "6.2"

--- a/Sources/Graphs/AlgorithmDefinitions/Utils/GraphProperty.swift
+++ b/Sources/Graphs/AlgorithmDefinitions/Utils/GraphProperty.swift
@@ -3,11 +3,11 @@
 /// Conforming types must provide a default value that is used when a property has not been explicitly set.
 /// Use ``VertexProperty`` for vertex properties and ``EdgeProperty`` for edge properties.
 public protocol GraphProperty<Value> {
-    // Swift 5.9/6.0 enforce `Value: Sendable` too strictly: `DistanceProperty<Weight>` and
+    // Swift 5.9–6.1 enforce `Value: Sendable` too strictly: `DistanceProperty<Weight>` and
     // `PredecessorEdgeProperty<Edge>` fail to compile because the algorithm generic params
-    // (Weight, Edge) lack a Sendable constraint. 6.1+ relaxed this. Restoring the constraint
-    // on 6.1+ lets PropertyValues use typed `any Sendable` storage.
-    #if compiler(>=6.1)
+    // (Weight, Edge) lack a Sendable constraint. 6.2+ relaxed this. Restoring the constraint
+    // on 6.2+ lets PropertyValues use typed `any Sendable` storage.
+    #if compiler(>=6.2)
     associatedtype Value: Sendable
     #else
     associatedtype Value

--- a/Sources/Graphs/GraphDefinitions/MutablePropertyGraph.swift
+++ b/Sources/Graphs/GraphDefinitions/MutablePropertyGraph.swift
@@ -15,8 +15,8 @@ extension VertexMutablePropertyGraph {
         return vertex
     }
 
-    // Swift 5.9/6.0 SIL bug: see DictionaryPropertyMap for details.
-    #if compiler(>=6.1)
+    // Swift 5.9–6.1 SIL crash: see DictionaryPropertyMap for details.
+    #if compiler(>=6.2)
     @inlinable
     public subscript(vertex: VertexPropertyMap.Key) -> VertexPropertyMap.Value {
         set { vertexPropertyMap[vertex] = newValue }
@@ -57,8 +57,8 @@ extension EdgeMutablePropertyGraph {
         return edge
     }
 
-    // Swift 5.9/6.0 SIL bug: see DictionaryPropertyMap for details.
-    #if compiler(>=6.1)
+    // Swift 5.9–6.1 SIL crash: see DictionaryPropertyMap for details.
+    #if compiler(>=6.2)
     @inlinable
     public subscript(edge: EdgePropertyMap.Key) -> EdgePropertyMap.Value {
         set { edgePropertyMap[edge] = newValue }

--- a/Sources/Graphs/GraphImplementations/Utils/DictionaryPropertyMap.swift
+++ b/Sources/Graphs/GraphImplementations/Utils/DictionaryPropertyMap.swift
@@ -18,10 +18,10 @@ public struct DictionaryPropertyMap<Key: Hashable, Value> {
 }
 
 extension DictionaryPropertyMap: MutablePropertyMap {
-    // Swift 5.9/6.0 have a SIL LinearLifetimeChecker bug that causes compiler crashes
-    // ("UNREACHABLE at LinearLifetimeCheckerPrivate.h") when _read/_modify coroutines are
-    // used in @inlinable code. Fixed in Swift 6.1+. Plain get/set is the fallback.
-    #if compiler(>=6.1)
+    // Swift 5.9–6.1 crash in the SIL DiagnoseStaticExclusivity pass when _read/_modify
+    // coroutines appear in @inlinable code (stack: DiagnoseStaticExclusivity::run()).
+    // Fixed in Swift 6.2+. Plain get/set is the fallback.
+    #if compiler(>=6.2)
     @inlinable
     public subscript(key: Key) -> Value {
         set { values[key] = newValue }

--- a/Sources/Graphs/GraphImplementations/Utils/PropertyValues.swift
+++ b/Sources/Graphs/GraphImplementations/Utils/PropertyValues.swift
@@ -10,8 +10,8 @@ public struct VertexPropertyValues: VertexProperties {
     ///
     /// - Parameter property: The type of property to access
     /// - Returns: The current value of the property
-    // Swift 5.9/6.0 SIL bug: see DictionaryPropertyMap for details.
-    #if compiler(>=6.1)
+    // Swift 5.9–6.1 SIL crash: see DictionaryPropertyMap for details.
+    #if compiler(>=6.2)
     public subscript<P: VertexProperty>(property: P.Type) -> P.Value {
         set { storage[property] = newValue }
         _read { yield storage[property] }
@@ -45,8 +45,8 @@ public struct EdgePropertyValues: EdgeProperties {
     ///
     /// - Parameter property: The type of property to access
     /// - Returns: The current value of the property
-    // Swift 5.9/6.0 SIL bug: see DictionaryPropertyMap for details.
-    #if compiler(>=6.1)
+    // Swift 5.9–6.1 SIL crash: see DictionaryPropertyMap for details.
+    #if compiler(>=6.2)
     public subscript<P: EdgeProperty>(property: P.Type) -> P.Value {
         set { storage[property] = newValue }
         _read { yield storage[property] }
@@ -68,7 +68,7 @@ public struct EdgePropertyValues: EdgeProperties {
     public init() {}
 }
 
-#if compiler(>=6.1)
+#if compiler(>=6.2)
 private struct PropertyValues: Sendable {
     private var storage: [ObjectIdentifier: any Sendable] = [:]
 

--- a/Tests/GraphsTests/Core/SendableConformanceTests.swift
+++ b/Tests/GraphsTests/Core/SendableConformanceTests.swift
@@ -93,7 +93,7 @@ struct SendableConformanceTests {
 
 // Static assertion: if this function compiles the default AdjacencyList() satisfies Sendable.
 // It is never called at runtime.
-#if compiler(>=6.1)
+#if compiler(>=6.2)
 @inline(never)
 private func _assertDefaultAdjacencyListIsSendable() {
     func require<T: Sendable>(_: T.Type) {}


### PR DESCRIPTION
Also adds Swift 6.1 to the CI matrix so this class of regression is caught before it reaches SPI.

https://swiftpackageindex.com/builds/102537AF-DB87-4075-8DBC-BE9EF4F85DC4